### PR TITLE
Create routines

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -14,6 +14,7 @@ import { RootState } from '../../app/store'
 import { logout, retrieveSession } from '../../supabase/SupabaseSlice'
 import { AppBar, Box, Button, Toolbar, Typography } from '@material-ui/core'
 import { useEffect } from 'react'
+import RoutinePage from '../../pages/RoutinePage/RoutinePage'
 
 function App() {
   const loading = useSelector((state: RootState) => state.supabase.loading)
@@ -56,6 +57,7 @@ function App() {
             <Route path="/Signup" element={<SignUpPage />} />
             <Route path="/Account" element={<AccountPage />} />
             <Route path="/ForgotPassword" element={<ForgotPasswordPage />} />
+            <Route path="/Routine" element={<RoutinePage />} />
           </Routes>
         </BrowserRouter>
       </div>

--- a/src/components/Services/Backend/SwoleBackend.tsx
+++ b/src/components/Services/Backend/SwoleBackend.tsx
@@ -1,0 +1,13 @@
+import axios from 'axios'
+import { store } from '../../../app/store'
+
+export async function retrieveExercises(): Promise<any> {
+  return await axios.get(
+    process.env.REACT_APP_SWOLE_BACKEND_URL! + '/WeatherForecast',
+    {
+      headers: {
+        Authorization: store.getState().supabase.session?.access_token,
+      },
+    }
+  )
+}

--- a/src/components/Services/Backend/SwoleBackend.tsx
+++ b/src/components/Services/Backend/SwoleBackend.tsx
@@ -1,9 +1,20 @@
 import axios from 'axios'
 import { store } from '../../../app/store'
 
-export async function retrieveExercises(): Promise<any> {
+export async function retrieveWeather(): Promise<any> {
   return await axios.get(
     process.env.REACT_APP_SWOLE_BACKEND_URL! + '/WeatherForecast',
+    {
+      headers: {
+        Authorization: store.getState().supabase.session?.access_token,
+      },
+    }
+  )
+}
+
+export async function retrieveExercises(): Promise<any> {
+  return await axios.get(
+    process.env.REACT_APP_SWOLE_BACKEND_URL! + '/GetExercises',
     {
       headers: {
         Authorization: store.getState().supabase.session?.access_token,

--- a/src/components/modals/ExerciseModal/ExerciseModal.tsx
+++ b/src/components/modals/ExerciseModal/ExerciseModal.tsx
@@ -13,7 +13,9 @@ export default function Modal(props: ModalType) {
       <>
         {props.isOpen && (
           <div className="modal-overlay" onClick={props.toggle}>
-            <div className="modal-box">{props.children}</div>
+            <div onClick={e => e.stopPropagation()} className="modal-box">
+              {props.children}
+            </div>
           </div>
         )}
       </>
@@ -41,5 +43,6 @@ const css2 = `
   height: 70%;
   padding: 1rem;
   border-radius: 1rem;
+  overflow-y: scroll;
 }
         `

--- a/src/components/modals/ExerciseModal/ExerciseModal.tsx
+++ b/src/components/modals/ExerciseModal/ExerciseModal.tsx
@@ -1,0 +1,45 @@
+import React, { ReactNode } from 'react'
+
+interface ModalType {
+  children?: ReactNode
+  isOpen: boolean
+  toggle: () => void
+}
+
+export default function Modal(props: ModalType) {
+  return (
+    <div>
+      <style>{css2}</style>
+      <>
+        {props.isOpen && (
+          <div className="modal-overlay" onClick={props.toggle}>
+            <div className="modal-box">{props.children}</div>
+          </div>
+        )}
+      </>
+    </div>
+  )
+}
+
+const css2 = `
+.modal-overlay {
+  z-index: 9999;
+  width: 100vw;
+  height: 100vh;
+  position: absolute;
+  top: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-box {
+  display: block;
+  background: white;
+  width: 70%;
+  height: 70%;
+  padding: 1rem;
+  border-radius: 1rem;
+}
+        `

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { Navigate, redirect } from 'react-router-dom'
 import { RootState } from '../../app/store'
-
+import { retrieveExercises } from '../../components/Services/Backend/SwoleBackend'
 const AccountPage = () => {
   let dataSet:
     | {
@@ -24,8 +24,6 @@ const AccountPage = () => {
     RenderForecasts()
   }, [])
 
-  // TODO: Find a way to store session in cache so it isn't lost on refresh
-
   // Don't allow user to access this if session is null
   if (session === null) {
     console.log('null session: ' + session)
@@ -35,30 +33,10 @@ const AccountPage = () => {
   async function RenderForecasts() {
     setLoading(true)
 
-    axios
-      .get(process.env.REACT_APP_SWOLE_BACKEND_URL! + '/WeatherForecast', {
-        headers: { Authorization: session?.access_token },
-      })
-      .then(response => {
-        setWeatherData(response.data ?? [])
-      })
-      .catch(function (error) {
-        if (error.response.status === 401) {
-          console.log('Account Error: ' + error.response.data.message)
+    await retrieveExercises().then(response => {
+      setWeatherData(response.data ?? [])
+    })
 
-          // TODO: send user back to login page
-        } else if (error.response) {
-          // The request was made and the server responded with a status code
-          // that falls out of the range of 2xx
-          console.log(error.response.data)
-          alert(error.response.data.message)
-        } else {
-          // Something happened in setting up the request that triggered an Error
-          console.log('Error', error.message)
-          alert('Error: ' + error.message)
-        }
-        console.log(error.config)
-      })
     setLoading(false)
   }
 

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { Navigate, redirect } from 'react-router-dom'
 import { RootState } from '../../app/store'
-import { retrieveExercises } from '../../components/Services/Backend/SwoleBackend'
+import { retrieveWeather } from '../../components/Services/Backend/SwoleBackend'
 const AccountPage = () => {
   let dataSet:
     | {
@@ -33,7 +33,7 @@ const AccountPage = () => {
   async function RenderForecasts() {
     setLoading(true)
 
-    await retrieveExercises().then(response => {
+    await retrieveWeather().then(response => {
       setWeatherData(response.data ?? [])
     })
 

--- a/src/pages/RoutinePage/RoutinePage.tsx
+++ b/src/pages/RoutinePage/RoutinePage.tsx
@@ -4,19 +4,47 @@ import InputForm, {
   InputType,
 } from '../../components/forms/InputForm/InputForm'
 import { RootState } from '../../app/store'
-import { Typography } from '@material-ui/core'
+import { Button, Typography } from '@material-ui/core'
+import { useState } from 'react'
 
 const RoutinePage = () => {
-  const session = useSelector((state: RootState) => state.supabase.session)
+  type Item = {
+    itemName: string
+    repetitions: number
+    sets: number
+  }
 
-  if (session === null) {
-    console.log(session)
-    return <Navigate to="/" />
+  let dataSet: Item[] | null = []
+  const session = useSelector((state: RootState) => state.supabase.session)
+  const [itemData, setItemData] = useState(dataSet)
+
+  // TODO: look into why this sends to Account when signed in
+  //   if (session === null) {
+  //     console.log(session)
+  //     return <Navigate to="/" />
+  //   }
+
+  // Add hardcoded item for now
+  function AddItem() {
+    let newItem: Item = { itemName: 'Item Name', repetitions: 3, sets: 3 }
+    setItemData(itemData.concat(newItem))
   }
 
   return (
     <div>
       <Typography>Routine Page</Typography>
+      {/* Add super generic item  */}
+      <Button onClick={AddItem}>Add</Button>
+      {itemData?.map((element, i) => (
+        <div key={i}>
+          Item {i}
+          <br />
+          <p>Name: {element.itemName}</p>
+          <p>Reps: {element.repetitions}</p>
+          <p>Sets: {element.sets}</p>
+          <hr />
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/pages/RoutinePage/RoutinePage.tsx
+++ b/src/pages/RoutinePage/RoutinePage.tsx
@@ -10,12 +10,6 @@ import Modal from '../../components/modals/ExerciseModal/ExerciseModal'
 import { retrieveExercises } from '../../components/Services/Backend/SwoleBackend'
 
 const RoutinePage = () => {
-  type Item = {
-    itemName: string
-    repetitions: number
-    sets: number
-  }
-
   type ExerciseItem = {
     created_at: string
     exercise_description: string | null
@@ -44,21 +38,6 @@ const RoutinePage = () => {
     //return <Navigate to="/" />
   }
 
-  function AddItem(item: Item) {
-    //setItemData(itemData.concat(item))
-    closeModal()
-  }
-
-  // TODO: this should be moved out to own class where we retrieve the data.
-  // this data should then populate the modal
-  // Add hardcoded item for now
-  function AddModalItem() {
-    let newItem: Item = { itemName: 'Item Name', repetitions: 3, sets: 3 }
-    //setItemModalData(itemModalData.concat(newItem))
-
-    // TODO: Retrieve From backend and populate
-  }
-
   async function PopulateModal() {
     await retrieveExercises().then(response => {
       console.log(response.data)
@@ -67,11 +46,10 @@ const RoutinePage = () => {
   }
 
   useEffect(() => {
-    // Add 10 dummy items
+    // Populate Modal with DB items
     if (session !== null && itemModalData.length < 1) {
       PopulateModal()
       console.log('Modal was populated')
-      //AddModalItem()
     }
   })
 

--- a/src/pages/RoutinePage/RoutinePage.tsx
+++ b/src/pages/RoutinePage/RoutinePage.tsx
@@ -1,0 +1,24 @@
+import { useSelector } from 'react-redux'
+import { Link, Navigate } from 'react-router-dom'
+import InputForm, {
+  InputType,
+} from '../../components/forms/InputForm/InputForm'
+import { RootState } from '../../app/store'
+import { Typography } from '@material-ui/core'
+
+const RoutinePage = () => {
+  const session = useSelector((state: RootState) => state.supabase.session)
+
+  if (session === null) {
+    console.log(session)
+    return <Navigate to="/" />
+  }
+
+  return (
+    <div>
+      <Typography>Routine Page</Typography>
+    </div>
+  )
+}
+
+export default RoutinePage

--- a/src/pages/RoutinePage/RoutinePage.tsx
+++ b/src/pages/RoutinePage/RoutinePage.tsx
@@ -6,6 +6,7 @@ import InputForm, {
 import { RootState } from '../../app/store'
 import { Button, Typography } from '@material-ui/core'
 import { useState } from 'react'
+import Modal from '../../components/modals/ExerciseModal/ExerciseModal'
 
 const RoutinePage = () => {
   type Item = {
@@ -17,6 +18,12 @@ const RoutinePage = () => {
   let dataSet: Item[] | null = []
   const session = useSelector((state: RootState) => state.supabase.session)
   const [itemData, setItemData] = useState(dataSet)
+  const [isOpen, setisOpen] = useState(false)
+
+  const toggle = () => {
+    console.log('toggling')
+    setisOpen(!isOpen)
+  }
 
   // TODO: look into why this sends to Account when signed in
   //   if (session === null) {
@@ -44,7 +51,9 @@ const RoutinePage = () => {
         }}
       >
         <Button onClick={AddItem}>Add</Button>
+        <Button onClick={toggle}>Toggle</Button>
       </div>
+      <Modal isOpen={isOpen} toggle={toggle}></Modal>
       {itemData?.map((element, i) => (
         <div key={i}>
           Item {i}

--- a/src/pages/RoutinePage/RoutinePage.tsx
+++ b/src/pages/RoutinePage/RoutinePage.tsx
@@ -34,7 +34,17 @@ const RoutinePage = () => {
     <div>
       <Typography>Routine Page</Typography>
       {/* Add super generic item  */}
-      <Button onClick={AddItem}>Add</Button>
+      <div
+        style={{
+          color: 'inherit',
+          marginRight: 0,
+          marginLeft: 'auto',
+          alignItems: 'end',
+          display: 'table',
+        }}
+      >
+        <Button onClick={AddItem}>Add</Button>
+      </div>
       {itemData?.map((element, i) => (
         <div key={i}>
           Item {i}

--- a/src/pages/RoutinePage/RoutinePage.tsx
+++ b/src/pages/RoutinePage/RoutinePage.tsx
@@ -5,7 +5,7 @@ import InputForm, {
 } from '../../components/forms/InputForm/InputForm'
 import { RootState } from '../../app/store'
 import { Button, Typography } from '@material-ui/core'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Modal from '../../components/modals/ExerciseModal/ExerciseModal'
 
 const RoutinePage = () => {
@@ -16,13 +16,17 @@ const RoutinePage = () => {
   }
 
   let dataSet: Item[] | null = []
+  let modalDataSet: Item[] | null = []
   const session = useSelector((state: RootState) => state.supabase.session)
   const [itemData, setItemData] = useState(dataSet)
+  const [itemModalData, setItemModalData] = useState(modalDataSet)
   const [isOpen, setisOpen] = useState(false)
 
   const toggle = () => {
-    console.log('toggling')
     setisOpen(!isOpen)
+  }
+  const closeModal = () => {
+    setisOpen(false)
   }
 
   // TODO: look into why this sends to Account when signed in
@@ -31,11 +35,25 @@ const RoutinePage = () => {
   //     return <Navigate to="/" />
   //   }
 
-  // Add hardcoded item for now
-  function AddItem() {
-    let newItem: Item = { itemName: 'Item Name', repetitions: 3, sets: 3 }
-    setItemData(itemData.concat(newItem))
+  function AddItem(item: Item) {
+    setItemData(itemData.concat(item))
+    closeModal()
   }
+
+  // TODO: this should be moved out to own class where we retrieve the data.
+  // this data should then populate the modal
+  // Add hardcoded item for now
+  function AddModalItem() {
+    let newItem: Item = { itemName: 'Item Name', repetitions: 3, sets: 3 }
+    setItemModalData(itemModalData.concat(newItem))
+  }
+
+  useEffect(() => {
+    // Add 10 dummy items
+    if (itemModalData.length < 10) {
+      AddModalItem()
+    }
+  })
 
   return (
     <div>
@@ -50,10 +68,23 @@ const RoutinePage = () => {
           display: 'table',
         }}
       >
-        <Button onClick={AddItem}>Add</Button>
         <Button onClick={toggle}>Toggle</Button>
       </div>
-      <Modal isOpen={isOpen} toggle={toggle}></Modal>
+      <Modal
+        children={itemModalData?.map((element, i) => (
+          <div key={i}>
+            Item {i}
+            <br />
+            <p>Name: {element.itemName}</p>
+            <p>Reps: {element.repetitions}</p>
+            <p>Sets: {element.sets}</p>
+            <Button onClick={() => AddItem(element)}>Add Item</Button>
+            <hr />
+          </div>
+        ))}
+        isOpen={isOpen}
+        toggle={toggle}
+      ></Modal>
       {itemData?.map((element, i) => (
         <div key={i}>
           Item {i}

--- a/src/pages/RoutinePage/RoutinePage.tsx
+++ b/src/pages/RoutinePage/RoutinePage.tsx
@@ -7,6 +7,7 @@ import { RootState } from '../../app/store'
 import { Button, Typography } from '@material-ui/core'
 import { useEffect, useState } from 'react'
 import Modal from '../../components/modals/ExerciseModal/ExerciseModal'
+import { retrieveExercises } from '../../components/Services/Backend/SwoleBackend'
 
 const RoutinePage = () => {
   type Item = {
@@ -15,8 +16,16 @@ const RoutinePage = () => {
     sets: number
   }
 
-  let dataSet: Item[] | null = []
-  let modalDataSet: Item[] | null = []
+  type ExerciseItem = {
+    created_at: string
+    exercise_description: string | null
+    exercise_id: number
+    exercise_name: string
+    exercise_type: string
+  }
+
+  let dataSet: ExerciseItem[] | null = []
+  let modalDataSet: ExerciseItem[] | null = []
   const session = useSelector((state: RootState) => state.supabase.session)
   const [itemData, setItemData] = useState(dataSet)
   const [itemModalData, setItemModalData] = useState(modalDataSet)
@@ -29,14 +38,14 @@ const RoutinePage = () => {
     setisOpen(false)
   }
 
-  // TODO: look into why this sends to Account when signed in
-  //   if (session === null) {
-  //     console.log(session)
-  //     return <Navigate to="/" />
-  //   }
+  //TODO: look into why this sends to Account when signed in
+  if (session === null) {
+    console.log(session)
+    //return <Navigate to="/" />
+  }
 
   function AddItem(item: Item) {
-    setItemData(itemData.concat(item))
+    //setItemData(itemData.concat(item))
     closeModal()
   }
 
@@ -45,13 +54,24 @@ const RoutinePage = () => {
   // Add hardcoded item for now
   function AddModalItem() {
     let newItem: Item = { itemName: 'Item Name', repetitions: 3, sets: 3 }
-    setItemModalData(itemModalData.concat(newItem))
+    //setItemModalData(itemModalData.concat(newItem))
+
+    // TODO: Retrieve From backend and populate
+  }
+
+  async function PopulateModal() {
+    await retrieveExercises().then(response => {
+      console.log(response.data)
+      setItemModalData(response.data ?? [])
+    })
   }
 
   useEffect(() => {
     // Add 10 dummy items
-    if (itemModalData.length < 10) {
-      AddModalItem()
+    if (session !== null && itemModalData.length < 1) {
+      PopulateModal()
+      console.log('Modal was populated')
+      //AddModalItem()
     }
   })
 
@@ -75,10 +95,20 @@ const RoutinePage = () => {
           <div key={i}>
             Item {i}
             <br />
-            <p>Name: {element.itemName}</p>
-            <p>Reps: {element.repetitions}</p>
-            <p>Sets: {element.sets}</p>
-            <Button onClick={() => AddItem(element)}>Add Item</Button>
+            <p>created_at: {element.created_at}</p>
+            <p>exercise_description: {element.exercise_description}</p>
+            <p>exercise_id: {element.exercise_id}</p>
+            <p>exercise_name: {element.exercise_name}</p>
+            <p>exercise_type: {element.exercise_type}</p>
+            <Button
+              onClick={() => {
+                console.log(element)
+                setItemData(itemData.concat(element))
+                closeModal()
+              }}
+            >
+              Add Item
+            </Button>
             <hr />
           </div>
         ))}
@@ -89,9 +119,11 @@ const RoutinePage = () => {
         <div key={i}>
           Item {i}
           <br />
-          <p>Name: {element.itemName}</p>
-          <p>Reps: {element.repetitions}</p>
-          <p>Sets: {element.sets}</p>
+          <p>created_at: {element.created_at}</p>
+          <p>exercise_description: {element.exercise_description}</p>
+          <p>exercise_id: {element.exercise_id}</p>
+          <p>exercise_name: {element.exercise_name}</p>
+          <p>exercise_type: {element.exercise_type}</p>
           <hr />
         </div>
       ))}


### PR DESCRIPTION
# Description
Allow the user to create a routine. The user has the option to toggle a Modal that is populated with data from the DB exercises table. This data will include generic information like exercise ID and Exercise name. Once the user selects an exercise, the item will then be added to the routine page.

# Showcase
![AddToRoutine](https://user-images.githubusercontent.com/30638262/232354746-035ad9c0-4adb-4535-a017-429fa267d833.gif)

# Downsides
The routine page could use more work in terms of being displayed. For example, the exercise ID should not be displayed to the user. As of right now, the routine created by the user is only local but we should have the option to save this routine and store it in the DB, associated with the user.